### PR TITLE
Update to the template to fix the visibility bug on Windows machines

### DIFF
--- a/ll-property-association.html
+++ b/ll-property-association.html
@@ -74,6 +74,12 @@ UI for adding and removing property relations, configurable for any source, such
       margin: 15px 0 0;
     }
 
+    .temporaryfix {
+      max-height: 400px;
+      overflow-x: hidden;
+      overflow-y: scroll;
+    }
+
   </style>
 
   <template>
@@ -117,7 +123,7 @@ UI for adding and removing property relations, configurable for any source, such
 
       <h2>Associate this <span>[[_relationSourceSingularCapitalized]]</span> with more Properties</h2>
 
-      <div style="max-height: 400px; overflow-x: hidden; overflow-y: scroll;">
+      <div class="temporaryfix">
 
         <div class="row">
           <div class="col-md-5">

--- a/ll-property-association.html
+++ b/ll-property-association.html
@@ -115,7 +115,7 @@ UI for adding and removing property relations, configurable for any source, such
     <curtain-dialog id="unassociatedUnitsTableContainer" modal entry-animation="slide-down-animation"
                     exit-animation="slide-up-animation">
 
-      <h2>Associate this <span>[[_relationSourceSingularCapitalized]]</span> with more Properties goat effer</h2>
+      <h2>Associate this <span>[[_relationSourceSingularCapitalized]]</span> with more Properties</h2>
 
       <div style="max-height: 400px; overflow-x: hidden; overflow-y: scroll;">
 

--- a/ll-property-association.html
+++ b/ll-property-association.html
@@ -115,9 +115,9 @@ UI for adding and removing property relations, configurable for any source, such
     <curtain-dialog id="unassociatedUnitsTableContainer" modal entry-animation="slide-down-animation"
                     exit-animation="slide-up-animation">
 
-      <h2>Associate this <span>[[_relationSourceSingularCapitalized]]</span> with more Properties</h2>
+      <h2>Associate this <span>[[_relationSourceSingularCapitalized]]</span> with more Properties goat effer</h2>
 
-      <div>
+      <div style="max-height: 400px; overflow-x: hidden; overflow-y: scroll;">
 
         <div class="row">
           <div class="col-md-5">


### PR DESCRIPTION
This is a temporary fix to the modal.  Setting the max height to 400px, hiding overflow x, and using a scroll on overflow y.  Eventually we will update the polymer element to resize the modal based on the window size and resize events.
